### PR TITLE
WOA18 to WOA13 utility program + z_woa13 optionally convert TEMP to PTEMP

### DIFF
--- a/README.tools/README.tools.config.setup
+++ b/README.tools/README.tools.config.setup
@@ -30,6 +30,9 @@ simplest case these are:
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/config/intelGF_setup
+++ b/config/intelGF_setup
@@ -35,6 +35,9 @@ RM            = \rm -f
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/config/intelIF_setup
+++ b/config/intelIF_setup
@@ -36,6 +36,9 @@ RM            = \rm -f
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/config/intelPGF_setup
+++ b/config/intelPGF_setup
@@ -35,6 +35,9 @@ RM            = \rm -f
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/config/sp4XLF_setup
+++ b/config/sp4XLF_setup
@@ -49,6 +49,9 @@ RM            = \rm -f
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/config/xc30IF_setup
+++ b/config/xc30IF_setup
@@ -37,6 +37,9 @@ RM            = \rm -f
 # rules.
 #
 
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
 .c.o:
 	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
 

--- a/relax/src/Makefile
+++ b/relax/src/Makefile
@@ -7,8 +7,11 @@
 #
 
 .SUFFIXES: 
-.SUFFIXES: .c .F .f .o
+.SUFFIXES: .c .F .f .o .f90
 
+.f90:
+	@echo "Must have an explicit rule for" $*
+	@exit 1
 .F:
 	@echo "Must have an explicit rule for" $*
 	@exit 1
@@ -34,6 +37,7 @@ clean:
 	/bin/rm *.o *.a *.mod *.inc M*log *at *pf *noaa *s *u *u2 *gdem3 *gdem4 *gdem42 *woa *woa13 *density *cer *st *ve *fy *km *field *xi *xv bottom *_linear
 
 MODS = mod_xc.o mod_za.o wtime.o
+MODA = $(MODS) mod_ppsw.o
 LIBS = blkdat.o interp.o zh.o
 LIBN = blkdat.o interp.o zh.o $(EXTRANCDF)
 
@@ -70,8 +74,11 @@ z_woa_med78:     $(MODS) z_woa_med78.o           $(LIBS)
 z_woa_tracer:    $(MODS) z_woa_tracer.o          $(LIBS)
 	$(LD) $(LDFLAGS) z_woa_tracer.o  $(MODS) $(LIBN) -o z_woa_tracer
 
-z_woa13:         $(MODS) z_woa13.o               $(LIBS)
-	$(LD) $(LDFLAGS) z_woa13.o       $(MODS) $(LIBN) -o z_woa13
+woa18_to_woa13_format:   woa18_to_woa13_format.o
+	$(LD) $(LDFLAGS) woa18_to_woa13_format.o $(EXTRANCDF) -o woa18_to_woa13_format
+
+z_woa13:         $(MODA) z_woa13.o               $(LIBS)
+	$(LD) $(LDFLAGS) z_woa13.o       $(MODA) $(LIBN) -o z_woa13
 
 sst_woa:         $(MODS) sst_woa.o               $(LIBS)
 	$(LD) $(LDFLAGS) sst_woa.o       $(MODS) $(LIBN) -o sst_woa

--- a/relax/src/mod_ppsw.F
+++ b/relax/src/mod_ppsw.F
@@ -1,0 +1,84 @@
+      module mod_ppsw
+c
+c --- parts of ppsw.f in a module
+c
+c separate set of subroutines, adapted from WHOI CTD group
+c     real function atg(s,t,p)
+c     real function theta(s,t0,p0,pr)
+c     function p80(dpth,xlat)
+c
+c n fofonoff & r millard
+c
+      contains
+
+      real function atg(s,t,p)
+c ****************************
+c adiabatic temperature gradient deg c per decibar
+c ref: bryden,h.,1973,deep-sea res.,20,401-408
+c units:
+c       pressure        p        decibars
+c       temperature     t        deg celsius (ipts-68)
+c       salinity        s        (ipss-78)
+c       adiabatic       atg      deg. c/decibar
+c checkvalue: atg=3.255976e-4 c/dbar for s=40 (ipss-78),
+c t=40 deg c,p0=10000 decibars
+      ds = s - 35.0
+      atg = (((-2.1687e-16*t+1.8676e-14)*t-4.6206e-13)*p
+     x+((2.7759e-12*t-1.1351e-10)*ds+((-5.4481e-14*t
+     x+8.733e-12)*t-6.7795e-10)*t+1.8741e-8))*p
+     x+(-4.2393e-8*t+1.8932e-6)*ds
+     x+((6.6228e-10*t-6.836e-8)*t+8.5258e-6)*t+3.5803e-5
+      end function atg
+
+      real function theta(s,t0,p0,pr)
+c ***********************************
+c to compute local potential temperature at pr
+c using bryden 1973 polynomial for adiabatic lapse rate
+c and runge-kutta 4-th order integration algorithm.
+c ref: bryden,h.,1973,deep-sea res.,20,401-408
+c fofonoff,n.,1977,deep-sea res.,24,489-491
+c units:
+c       pressure        p0       decibars
+c       temperature     t0       deg celsius (ipts-68)
+c       salinity        s        (ipss-78)
+c       reference prs   pr       decibars
+c       potential tmp.  theta    deg celsius
+c checkvalue: theta= 36.89073 c,s=40 (ipss-78),t0=40 deg c,
+c p0=10000 decibars,pr=0 decibars
+c
+c      set-up intermediate temperature and pressure variables
+      p=p0
+      t=t0
+c**************
+      h = pr - p
+      xk = h*atg(s,t,p)
+      t = t + 0.5*xk
+      q = xk
+      p = p + 0.5*h
+      xk = h*atg(s,t,p)
+      t = t + 0.29289322*(xk-q)
+      q = 0.58578644*xk + 0.121320344*q
+      xk = h*atg(s,t,p)
+      t = t + 1.707106781*(xk-q)
+      q = 3.414213562*xk - 4.121320344*q
+      p = p + 0.5*h
+      xk = h*atg(s,t,p)
+      theta = t + (xk-2.0*q)/6.0
+      end function theta
+
+c
+c pressure from depth from saunder's formula with eos80.
+c reference: saunders,peter m., practical conversion of pressure
+c            to depth., j.p.o. , april 1981.
+c r millard
+c march 9, 1983
+c check value: p80=7500.004 dbars;for lat=30 deg., depth=7321.45 meters
+      real function p80(dpth,xlat)
+      parameter pi=3.141592654
+      plat=abs(xlat*pi/180.)
+      d=sin(plat)
+      c1=5.92e-3+d**2*5.25e-3
+      p80=((1-c1)-sqrt(((1-c1)**2)-(8.84e-6*dpth)))/4.42e-6
+      end function p80
+
+      end module mod_ppsw

--- a/relax/src/woa18_to_woa13_format.f90
+++ b/relax/src/woa18_to_woa13_format.f90
@@ -1,0 +1,329 @@
+program woa18_to_woa13_format
+  use netcdf
+  implicit none
+  character(len=199) :: fname, pgm
+  character(len=199) :: standard_name, long_name, cell_methods, grid_mapping
+  real(4), dimension(:,:,:),allocatable :: dat
+  real(4), dimension(:),allocatable :: lon,lat,depth
+  real(4) :: FillValue
+  integer :: nx,ny,nz, nz1, dims(4)
+  integer :: ncid, varid, nxid,nyid,nzid
+
+  integer :: mm,qq,i,j,z, iargc
+
+  !-- Usage -----------------------------------------------------------+
+  if (iargc()>0) then
+    call getarg(1,pgm)
+    if (pgm(1:2)=='-h' .or. pgm(1:3)=='--h') then
+      call getarg(0,pgm)
+      write(0,*)'Reformat WOA18 data similar to WOA13_v2.tgz'
+      write(0,*)'  1) Monthly data padded with quarter data for deeper layers'
+      write(0,*)'  2) Interpolate over land. Ugly plots but needed for HYCOM relax fields'
+      write(0,*)''
+      write(0,*)"USAGE:  "//trim(pgm)//" (NO-arguments, but run in the same directory as input files)"
+      write(0,*)''
+      write(0,*)'Input:  woa18_decav_s<MM>_04.nc'
+      write(0,*)'        woa18_decav_t<MM>_04.nc'
+      write(0,*)'Output: WOA18_SALT_m<MM>.nc'
+      write(0,*)'        WOA18_TEMP_m<MM>.nc'
+      write(0,*)''
+      write(0,*)'WOA18 data source:'
+      write(0,*)'  https://data.nodc.noaa.gov/woa/WOA18/DATA/salinity/netcdf/decav/0.25/'
+      write(0,*)'  https://data.nodc.noaa.gov/woa/WOA18/DATA/temperature/netcdf/decav/0.25/'
+      write(0,*)''
+!      write(0,*)'Mads Hvid Ribergaard, DMI'
+      call exit(1)
+    endif
+  endif
+
+  !-- Read dimensions ------------------------------------------------+
+  
+  ! Quarter fields
+  fname='woa18_decav_s16_04.nc'
+  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
+  call nc_check('nc inquire',nf90_inquire_variable(ncid,varid,dimids=dims(:4)))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(1),len=nx))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(2),len=ny))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(3),len=nz))
+  call nc_check('nc close',  nf90_close(ncid))
+
+  ! Monthly fields
+  fname='woa18_decav_s01_04.nc'
+  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
+  call nc_check('nc inquire',nf90_inquire_variable(ncid,varid,dimids=dims(:4)))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(1),len=nx))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(2),len=ny))
+  call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(3),len=nz1))
+  call nc_check('nc close',  nf90_close(ncid))
+
+  !-- Allocate -------------------------------------------------------+
+  allocate(lon(nx),lat(ny),depth(nz),dat(nx,ny,nz))
+
+  !-- Read stationary fields: lon,lat,depth --------------------------+
+  fname='woa18_decav_s16_04.nc'
+  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc varid',  nf90_inq_varid(ncid,'lon',varid))
+  call nc_check('nc get_var',nf90_get_var(ncid,varid,lon(:)))
+  call nc_check('nc varid',  nf90_inq_varid(ncid,'lat',varid))
+  call nc_check('nc get_var',nf90_get_var(ncid,varid,lat(:)))
+  call nc_check('nc varid',  nf90_inq_varid(ncid,'depth',varid))
+  call nc_check('nc get_var',nf90_get_var(ncid,varid,depth(:)))
+  call nc_check('nc close',  nf90_close(ncid))
+
+  !-- Loop foreach month ---------------------------------------------+
+  do mm=1,12
+    !-- Find quarter
+    select case (mm)
+      case (1:3)
+        qq=13  ! Winter
+      case (4:6)
+        qq=14  ! Spring
+      case (7:9)
+        qq=15  ! Summer
+      case (10:12)
+        qq=16  ! Autumn
+    end select
+!    select case (mm)
+!      case (12,1:2)
+!        qq=13  ! Winter
+!      case (3:5)
+!        qq=14  ! Spring
+!      case (6:8)
+!        qq=15  ! Summer
+!      case (9:11)
+!        qq=16  ! Autumn
+!    end select
+
+    !-- Salinity ------------------------------------------------------+
+
+    ! Surface: Monthly
+    write(fname,'(a,i2.2,a)')'woa18_decav_s',mm,'_04.nc'
+    write(*,*)'Read: ',trim(fname)
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
+    do z=1,nz1
+      call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z,1 /)))
+    enddo
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'_FillValue',FillValue))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'standard_name',standard_name))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'long_name',long_name))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'cell_methods',cell_methods))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'grid_mapping',grid_mapping))
+    call nc_check('nc close',  nf90_close(ncid))
+
+    ! Bottom: Quarterly
+    write(fname,'(a,i2.2,a)')'woa18_decav_s',qq,'_04.nc'
+    write(*,*)'Read: ',trim(fname)
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
+    do z=nz1+1,nz
+      call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
+    enddo
+    call nc_check('nc close',  nf90_close(ncid))
+
+    !-- Interpolate data
+    call fillmiss(dat,nx,ny,nz,FillValue) 
+
+    !-- Write: NetCDF file -- 
+    write(fname,'(a,i2.2,a)')'WOA18_SALT_m',mm,'.nc'
+    write(*,*)'Write: ',trim(fname)
+    call nc_check('nc create',nf90_create(trim(fname), nf90_clobber, ncid))
+    call nc_check('nc def nx',nf90_def_dim(ncid,'lon',nx, nxid))
+    call nc_check('nc def ny',nf90_def_dim(ncid,'lat',ny, nyid))
+    call nc_check('nc def nz',nf90_def_dim(ncid,'depth',nz, nzid))
+    call nc_check('nc var lon',nf90_def_var(ncid,'lon',nf90_float,(/nxid/),varid))
+    call nc_check('nc var lat',nf90_def_var(ncid,'lat',nf90_float,(/nyid/),varid))
+    call nc_check('nc var depth',nf90_def_var(ncid,'depth',nf90_float,(/nzid/),varid))
+    call nc_check('nc var SALT',nf90_def_var(ncid,'SALT',nf90_float,(/nxid,nyid,nzid/),varid))
+    call nc_check('nc FillValue',nf90_put_att(ncid,varid,'_FillValue',FillValue))
+    call nc_check('nc FillValue',nf90_put_att(ncid,varid,'missing_data',FillValue))
+    call nc_check('nc standard_name',nf90_put_att(ncid,varid,'standard_name',standard_name))
+    call nc_check('nc long_name',nf90_put_att(ncid,varid,'long_name',long_name))
+    call nc_check('nc cell_methods',nf90_put_att(ncid,varid,'cell_methods',cell_methods))
+    call nc_check('nc grid_mapping',nf90_put_att(ncid,varid,'grid_mapping',grid_mapping))
+    call nc_check('nc month',nf90_put_att(ncid,nf90_global,'month',mm))
+    call nc_check('nc quarter',nf90_put_att(ncid,nf90_global,'quarter',qq))
+    call nc_check('nc title',nf90_put_att(ncid,nf90_global,'title',&
+                    'Monthly WOA18 climatorology in WOA13 format using quarter values at depth'))
+    call nc_check('nc source',nf90_put_att(ncid,nf90_global,'source',&
+                     'https://www.nodc.noaa.gov/cgi-bin/OC5/woa18/woa18.pl'))
+    call nc_check('nc enddef',nf90_enddef(ncid))
+    call nc_check('nc close',nf90_close(ncid))
+
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_write, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'lon',varid))
+    call nc_check('nc put lon',nf90_put_var(ncid,varid,lon))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'lat',varid))
+    call nc_check('nc put lat',nf90_put_var(ncid,varid,lat))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'depth',varid))
+    call nc_check('nc put depth',nf90_put_var(ncid,varid,depth))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'SALT',varid))
+    do z=1,nz
+      call nc_check('nc put SALT',nf90_put_var(ncid,varid,dat(:,:,z),(/1,1,z/)))
+    enddo
+    call nc_check('nc close',nf90_close(ncid))
+    write(*,*)'-------'
+
+    !-- Temperature ---------------------------------------------------+
+  
+    ! Surface: Monthly
+    write(fname,'(a,i2.2,a)')'woa18_decav_t',mm,'_04.nc'
+    write(*,*)'Read: ',trim(fname)
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'t_an',varid))
+    do z=1,nz1
+      call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
+    enddo
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'_FillValue',FillValue))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'standard_name',standard_name))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'long_name',long_name))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'cell_methods',cell_methods))
+    call nc_check('nc get_att',nf90_get_att(ncid,varid,'grid_mapping',grid_mapping))
+    call nc_check('nc close',  nf90_close(ncid))
+
+    ! Bottom: Quarterly
+    write(fname,'(a,i2.2,a)')'woa18_decav_t',qq,'_04.nc'
+    write(*,*)'Read: ',trim(fname)
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'t_an',varid))
+    do z=nz1+1,nz
+      call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
+    enddo
+    call nc_check('nc close',  nf90_close(ncid))
+
+    !-- Interpolate data
+    call fillmiss(dat,nx,ny,nz,FillValue) 
+
+    !-- Write: NetCDF file -- 
+    write(fname,'(a,i2.2,a)')'WOA18_TEMP_m',mm,'.nc'
+    write(*,*)'Write: ',trim(fname)
+    call nc_check('nc create',nf90_create(trim(fname), nf90_clobber, ncid))
+    call nc_check('nc def nx',nf90_def_dim(ncid,'lon',nx, nxid))
+    call nc_check('nc def ny',nf90_def_dim(ncid,'lat',ny, nyid))
+    call nc_check('nc def nz',nf90_def_dim(ncid,'depth',nz, nzid))
+    call nc_check('nc var lon',nf90_def_var(ncid,'lon',nf90_float,(/nxid/),varid))
+    call nc_check('nc var lat',nf90_def_var(ncid,'lat',nf90_float,(/nyid/),varid))
+    call nc_check('nc var depth',nf90_def_var(ncid,'depth',nf90_float,(/nzid/),varid))
+    call nc_check('nc var TEMP',nf90_def_var(ncid,'TEMP',nf90_float,(/nxid,nyid,nzid/),varid))
+    call nc_check('nc FillValue',nf90_put_att(ncid,varid,'_FillValue',FillValue))
+    call nc_check('nc FillValue',nf90_put_att(ncid,varid,'missing_data',FillValue))
+    call nc_check('nc standard_name',nf90_put_att(ncid,varid,'standard_name',standard_name))
+    call nc_check('nc long_name',nf90_put_att(ncid,varid,'long_name',long_name))
+    call nc_check('nc cell_methods',nf90_put_att(ncid,varid,'cell_methods',cell_methods))
+    call nc_check('nc grid_mapping',nf90_put_att(ncid,varid,'grid_mapping',grid_mapping))
+    call nc_check('nc month',nf90_put_att(ncid,nf90_global,'month',mm))
+    call nc_check('nc quarter',nf90_put_att(ncid,nf90_global,'quarter',qq))
+    call nc_check('nc title',nf90_put_att(ncid,nf90_global,'title',&
+                    'Monthly WOA18 climatorology in WOA13 format using quarter values at depth'))
+    call nc_check('nc source',nf90_put_att(ncid,nf90_global,'source',&
+                     'https://www.nodc.noaa.gov/cgi-bin/OC5/woa18/woa18.pl'))
+    call nc_check('nc enddef', nf90_enddef(ncid))
+    call nc_check('nc close',nf90_close(ncid))
+
+    call nc_check('nc open',   nf90_open(trim(fname), nf90_write, ncid))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'lon',varid))
+    call nc_check('nc put lon',nf90_put_var(ncid,varid,lon))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'lat',varid))
+    call nc_check('nc put lat',nf90_put_var(ncid,varid,lat))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'depth',varid))
+    call nc_check('nc put depth',nf90_put_var(ncid,varid,depth))
+    call nc_check('nc varid',  nf90_inq_varid(ncid,'TEMP',varid))
+    do z=1,nz
+      call nc_check('nc put TEMP',nf90_put_var(ncid,varid,dat(:,:,z),(/1,1,z/)))
+    enddo
+    call nc_check('nc close',nf90_close(ncid))
+    write(*,*)'-------'
+
+  enddo
+
+!======================================================================
+contains
+!======================================================================
+
+subroutine nc_check(cnf90,status)
+!----------------------------------------------------------------------
+! subroutine to handle NetCDF errors
+
+  use netcdf
+  implicit none
+
+  character*(*), intent(in) :: cnf90
+  integer,       intent(in) :: status
+
+  if (status /= nf90_noerr) then
+    write(6,'(/a)')   'error from NetCDF library'
+    write(6,'(a/)')   trim(cnf90)
+    write(6,'(a/)')   trim(nf90_strerror(status))
+    stop
+  end if
+end subroutine nc_check
+
+!----------------------------------------------------------------------
+subroutine fillmiss(dat,nx,ny,nz,FillValue) 
+  ! Fill missing values using 4 neighbours.
+  !  Do it iterative until all points are filled
+  !  Do it foreach layer - ie. no vertical interpolation
+  implicit none
+  integer, intent(in) :: nx,ny,nz
+  real(4), intent(inout) :: dat(nx,ny,nz)
+  real(4), intent(in) :: FillValue
+  real(4) :: mval
+  integer :: i,j,k,Nmiss, Nok
+  integer :: i1,i2,j1,j2
+
+  do k=1,nz  ! Foreach level
+    do ! infinity loop: missing
+
+      Nmiss=0
+      do j=1,ny
+        do i=1,nx
+          if (dat(i,j,k)==FillValue) then
+            !-- Neighbor point indices
+            j1=max(j-1,1)
+            j2=min(j+1,ny)
+            i1=i-1
+            i2=i+1
+            if (i1<1)  i1=nx
+            if (i2>nx) i2=1
+            !-- Find finite points
+            Nok=0
+            mval=0.0
+            if (dat(i1,j,k)/=FillValue) then
+              mval=mval+dat(i1,j,k)
+              Nok=Nok+1
+            endif
+            if (dat(i2,j,k)/=FillValue) then
+              mval=mval+dat(i2,j,k)
+              Nok=Nok+1
+            endif
+            if (dat(i,j1,k)/=FillValue) then
+              mval=mval+dat(i,j1,k)
+              Nok=Nok+1
+            endif
+            if (dat(i,j2,k)/=FillValue) then
+              mval=mval+dat(i,j2,k)
+              Nok=Nok+1
+            endif
+            !-- Mean value using "Nok" finite points
+            if (Nok>0) then
+              dat(i,j,k)=mval/real(Nok)  
+            else
+              Nmiss=Nmiss+1
+            endif
+          endif
+        enddo
+      enddo
+      if (Nmiss == 0) exit
+      if (Nmiss == nx*ny) then
+        write(*,*)'WARNING: ALL point are marked as missing values, for level: ',k
+        exit
+      endif
+
+    enddo ! end infinity loop: missing
+  enddo ! k
+  
+end subroutine fillmiss
+  
+end program woa18_to_woa13_format

--- a/relax/src/woa18_to_woa13_format.f90
+++ b/relax/src/woa18_to_woa13_format.f90
@@ -17,10 +17,11 @@ program woa18_to_woa13_format
     if (pgm(1:2)=='-h' .or. pgm(1:3)=='--h') then
       call getarg(0,pgm)
       write(0,*)'Reformat WOA18 data similar to WOA13_v2.tgz'
-      write(0,*)'  1) Monthly data padded with quarter data for deeper layers'
-      write(0,*)'  2) Interpolate over land. Ugly plots but needed for HYCOM relax fields'
+      write(0,*)'  1) Monthly data (MM=01..12) padded with quarter data (MM=13..16) for deeper layers'
+      write(0,*)'  2) Interpolate over land. Ugly looking plots but needed for HYCOM relax fields'
       write(0,*)''
       write(0,*)"USAGE:  "//trim(pgm)//" (NO-arguments, but run in the same directory as input files)"
+      write(0,*)"        "//trim(pgm)//" --help"
       write(0,*)''
       write(0,*)'Input:  woa18_decav_s<MM>_04.nc'
       write(0,*)'        woa18_decav_t<MM>_04.nc'
@@ -31,6 +32,8 @@ program woa18_to_woa13_format
       write(0,*)'  https://data.nodc.noaa.gov/woa/WOA18/DATA/salinity/netcdf/decav/0.25/'
       write(0,*)'  https://data.nodc.noaa.gov/woa/WOA18/DATA/temperature/netcdf/decav/0.25/'
       write(0,*)''
+      write(0,*)'WOA18 info:'
+      write(0,*)'  https://www.nodc.noaa.gov/OC5/woa18/'
 !      write(0,*)'Mads Hvid Ribergaard, DMI'
       call exit(1)
     endif
@@ -40,7 +43,7 @@ program woa18_to_woa13_format
   
   ! Quarter fields
   fname='woa18_decav_s16_04.nc'
-  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
   call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
   call nc_check('nc inquire',nf90_inquire_variable(ncid,varid,dimids=dims(:4)))
   call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(1),len=nx))
@@ -50,7 +53,7 @@ program woa18_to_woa13_format
 
   ! Monthly fields
   fname='woa18_decav_s01_04.nc'
-  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
   call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
   call nc_check('nc inquire',nf90_inquire_variable(ncid,varid,dimids=dims(:4)))
   call nc_check('nc dim',    nf90_inquire_dimension(ncid,dims(1),len=nx))
@@ -63,7 +66,7 @@ program woa18_to_woa13_format
 
   !-- Read stationary fields: lon,lat,depth --------------------------+
   fname='woa18_decav_s16_04.nc'
-  call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+  call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
   call nc_check('nc varid',  nf90_inq_varid(ncid,'lon',varid))
   call nc_check('nc get_var',nf90_get_var(ncid,varid,lon(:)))
   call nc_check('nc varid',  nf90_inq_varid(ncid,'lat',varid))
@@ -101,7 +104,7 @@ program woa18_to_woa13_format
     ! Surface: Monthly
     write(fname,'(a,i2.2,a)')'woa18_decav_s',mm,'_04.nc'
     write(*,*)'Read: ',trim(fname)
-    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
     do z=1,nz1
       call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z,1 /)))
@@ -116,7 +119,7 @@ program woa18_to_woa13_format
     ! Bottom: Quarterly
     write(fname,'(a,i2.2,a)')'woa18_decav_s',qq,'_04.nc'
     write(*,*)'Read: ',trim(fname)
-    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'s_an',varid))
     do z=nz1+1,nz
       call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
@@ -129,7 +132,7 @@ program woa18_to_woa13_format
     !-- Write: NetCDF file -- 
     write(fname,'(a,i2.2,a)')'WOA18_SALT_m',mm,'.nc'
     write(*,*)'Write: ',trim(fname)
-    call nc_check('nc create',nf90_create(trim(fname), nf90_clobber, ncid))
+    call nc_check('nc create: '//trim(fname),nf90_create(trim(fname), nf90_clobber, ncid))
     call nc_check('nc def nx',nf90_def_dim(ncid,'lon',nx, nxid))
     call nc_check('nc def ny',nf90_def_dim(ncid,'lat',ny, nyid))
     call nc_check('nc def nz',nf90_def_dim(ncid,'depth',nz, nzid))
@@ -171,7 +174,7 @@ program woa18_to_woa13_format
     ! Surface: Monthly
     write(fname,'(a,i2.2,a)')'woa18_decav_t',mm,'_04.nc'
     write(*,*)'Read: ',trim(fname)
-    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'t_an',varid))
     do z=1,nz1
       call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
@@ -186,7 +189,7 @@ program woa18_to_woa13_format
     ! Bottom: Quarterly
     write(fname,'(a,i2.2,a)')'woa18_decav_t',qq,'_04.nc'
     write(*,*)'Read: ',trim(fname)
-    call nc_check('nc open',   nf90_open(trim(fname), nf90_nowrite, ncid))
+    call nc_check('nc open: '//trim(fname), nf90_open(trim(fname), nf90_nowrite, ncid))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'t_an',varid))
     do z=nz1+1,nz
       call nc_check('nc get_var',nf90_get_var(ncid,varid,dat(:,:,z),(/ 1,1,z /)))
@@ -199,7 +202,7 @@ program woa18_to_woa13_format
     !-- Write: NetCDF file -- 
     write(fname,'(a,i2.2,a)')'WOA18_TEMP_m',mm,'.nc'
     write(*,*)'Write: ',trim(fname)
-    call nc_check('nc create',nf90_create(trim(fname), nf90_clobber, ncid))
+    call nc_check('nc create: '//trim(fname),nf90_create(trim(fname), nf90_clobber, ncid))
     call nc_check('nc def nx',nf90_def_dim(ncid,'lon',nx, nxid))
     call nc_check('nc def ny',nf90_def_dim(ncid,'lat',ny, nyid))
     call nc_check('nc def nz',nf90_def_dim(ncid,'depth',nz, nzid))
@@ -222,7 +225,7 @@ program woa18_to_woa13_format
     call nc_check('nc enddef', nf90_enddef(ncid))
     call nc_check('nc close',nf90_close(ncid))
 
-    call nc_check('nc open',   nf90_open(trim(fname), nf90_write, ncid))
+    call nc_check('nc open: '//trim(fname),nf90_open(trim(fname), nf90_write, ncid))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'lon',varid))
     call nc_check('nc put lon',nf90_put_var(ncid,varid,lon))
     call nc_check('nc varid',  nf90_inq_varid(ncid,'lat',varid))
@@ -251,11 +254,17 @@ subroutine nc_check(cnf90,status)
 
   character*(*), intent(in) :: cnf90
   integer,       intent(in) :: status
+  character(len=199) :: pgm
 
   if (status /= nf90_noerr) then
-    write(6,'(/a)')   'error from NetCDF library'
-    write(6,'(a/)')   trim(cnf90)
-    write(6,'(a/)')   trim(nf90_strerror(status))
+    call getarg(0,pgm)
+    write(6,'(a)')''
+    write(6,'(a)')'> '//trim(pgm)//' --help'
+    call execute_command_line(trim(pgm)//' --help')
+    write(6,'(a)')''
+    write(6,'(a)')'ERROR from NetCDF library'
+    write(6,'(a)')trim(cnf90)
+    write(6,'(a)')trim(nf90_strerror(status))
     stop
   end if
 end subroutine nc_check
@@ -325,5 +334,5 @@ subroutine fillmiss(dat,nx,ny,nz,FillValue)
   enddo ! k
   
 end subroutine fillmiss
-  
+
 end program woa18_to_woa13_format

--- a/relax/src/woa18_to_woa13_format.f90
+++ b/relax/src/woa18_to_woa13_format.f90
@@ -17,8 +17,8 @@ program woa18_to_woa13_format
     if (pgm(1:2)=='-h' .or. pgm(1:3)=='--h') then
       call getarg(0,pgm)
       write(0,*)'Reformat WOA18 data similar to WOA13_v2.tgz'
-      write(0,*)'  1) Monthly data (MM=01..12) padded with quarter data (MM=13..16) for deeper layers'
-      write(0,*)'  2) Interpolate over land. Ugly looking plots but needed for HYCOM relax fields'
+      write(0,*)'  1) Monthly data (MM=01..12) padded with quarterly data (MM=13..16) for deeper layers'
+      write(0,*)'  2) Interpolate over land. Ugly looking plots but needed for HYCOM relax fields using z_woa13'
       write(0,*)''
       write(0,*)"USAGE:  "//trim(pgm)//" (NO-arguments, but run in the same directory as input files)"
       write(0,*)"        "//trim(pgm)//" --help"
@@ -259,7 +259,6 @@ subroutine nc_check(cnf90,status)
   if (status /= nf90_noerr) then
     call getarg(0,pgm)
     write(6,'(a)')''
-    write(6,'(a)')'> '//trim(pgm)//' --help'
     call execute_command_line(trim(pgm)//' --help')
     write(6,'(a)')''
     write(6,'(a)')'ERROR from NetCDF library'


### PR DESCRIPTION
1) Utility program to convert WOA18 clim. data to WOA13-a-like ready for z_woa13 utility:
- Merge monthly and seasonally data into one NetCDF file
- Interpolate/extrapolate over land and below sea-bed, which is needed 

2) z_woa13: Calculate PTEMP inline if only TEMP is found in NetCDF files. (update of PR #3) 
- Now using WHOI utilities - mod_ppsw.F - for calculating PTEMP using theta+p80
- Added option ICTYPE=5:
a) inforce stable density stratification (as ICTYPE=3)
b) use salinity dependent Freezing point Tf=-0.054*S (as ICTYPE=4)
