### PR TITLE
added -f flag to all make clean

### DIFF
--- a/force/src/Makefile
+++ b/force/src/Makefile
@@ -31,7 +31,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod M*log M*_?? ?? M*_[k]pc *fc *const *curl *diff *extend *fit *magstress *mm5 *nc *offset *scale *rivers *riv_mon *riv_hf *runoff *corr *zero *monthly *interp *shift *add *climo *diurnal *table *sal *core *barom *margin *wd stoch
+	/bin/rm -f *.o *.a *.mod M*log M*_?? ?? M*_[k]pc *fc *const *curl *diff *extend *fit *magstress *mm5 *nc *offset *scale *rivers *riv_mon *riv_hf *runoff *corr *zero *monthly *interp *shift *add *climo *diurnal *table *sal *core *barom *margin *wd stoch
 
 MODS = mod_xc.o mod_za.o wtime.o
 LIBS = interp.o zh.o

--- a/meanstd/src/Makefile
+++ b/meanstd/src/Makefile
@@ -31,7 +31,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod M*log *mnsq *std *diff *wsum
+	/bin/rm -f *.o *.a *.mod M*log *mnsq *std *diff *wsum
 
 MODS     =	mod_mean.o mod_mean_esmf.o mod_xc.o mod_za.o wtime.o zh.o
 

--- a/relax/src/Makefile
+++ b/relax/src/Makefile
@@ -34,7 +34,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod *.inc M*log *at *pf *noaa *s *u *u2 *gdem3 *gdem4 *gdem42 *woa *woa13 *density *cer *st *ve *fy *km *field *xi *xv bottom *_linear
+	/bin/rm -f *.o *.a *.mod *.inc M*log *at *pf *noaa *s *u *u2 *gdem3 *gdem4 *gdem42 *woa *woa13 *density *cer *st *ve *fy *km *field *xi *xv bottom *_linear
 
 MODS = mod_xc.o mod_za.o wtime.o
 MODA = $(MODS) mod_ppsw.o

--- a/roms/src/Makefile
+++ b/roms/src/Makefile
@@ -31,7 +31,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod M*log *grid
+	/bin/rm -f *.o *.a *.mod M*log *grid
 
 MODS = mod_xc.o mod_za.o wtime.o
 LIBS = zh.o

--- a/sample/src/Makefile
+++ b/sample/src/Makefile
@@ -31,7 +31,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod M*log *tspt *port *port2 *port3 *_lm *_baro *vel *mn *mn2 *mn3 *2p0
+	/bin/rm -f *.o *.a *.mod M*log *tspt *port *port2 *port3 *_lm *_baro *vel *mn *mn2 *mn3 *2p0
 
 MODS =	mod_trans.o mod_xc.o mod_za.o wtime.o
 OBJS =	blkin.o geopar.o getdat.o zh.o

--- a/subregion/src/Makefile
+++ b/subregion/src/Makefile
@@ -29,7 +29,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod *.inc M*log *pog *ion *nam *grid *arche *field *gmap *gmapi *count
+	/bin/rm -f *.o *.a *.mod *.inc M*log *pog *ion *nam *grid *arche *field *gmap *gmapi *count
 
 MODS = mod_xc.o mod_za.o mod_zb.o wtime.o zh.o
 

--- a/topo/src/Makefile
+++ b/topo/src/Makefile
@@ -31,7 +31,7 @@ all:
 	/bin/csh Make_all.csh
 
 clean:
-	/bin/rm *.o *.a *.mod netcdf.inc M*log *hgram *min *1d *2d *2h *ppmX *sea *oth *clip *ff *flat *fill *mask *set *shrink *sub *map *nam *sby *advect *trop *tor *rge *fy *it *noshrink *son *ude *zcells *zthin *arctic *_test *_ij *_resize *_ns *1deg  *lat *ts *ed *pe *gh *ip *15sec *30sec *bedmap *RTopo *sindhu *pi *sea-b *360 *island *vrtcmprs *lon *find *mom6 *dx *tiles *ic *1st
+	/bin/rm -f *.o *.a *.mod netcdf.inc M*log *hgram *min *1d *2d *2h *ppmX *sea *oth *clip *ff *flat *fill *mask *set *shrink *sub *map *nam *sby *advect *trop *tor *rge *fy *it *noshrink *son *ude *zcells *zthin *arctic *_test *_ij *_resize *_ns *1deg  *lat *ts *ed *pe *gh *ip *15sec *30sec *bedmap *RTopo *sindhu *pi *sea-b *360 *island *vrtcmprs *lon *find *mom6 *dx *tiles *ic *1st
 
 MODS = mod_xc.o mod_za.o wtime.o
 MODN = mod_xc.o mod_za.o wtime.o 


### PR DESCRIPTION
Some makefiles lacked the -f flag after rm in make clean, leading to spammy error messages. I added an -f flag where needed.