### PR TITLE
To build at NASA NCCS

### DIFF
--- a/Make_ncdf.src
+++ b/Make_ncdf.src
@@ -26,3 +26,9 @@ module   list
 setenv NCDFC	 ${NETCDFC_HOME}
 setenv NCDF	 ${NETCDFFORTRAN_HOME}
 setenv EXTRANCDF "-L${NCDFC}/lib -L${NCDF}/lib -lnetcdf -lnetcdff"
+#
+# --- NASA NCCS systems with mpiifort:
+# module load comp/intel/2021.3.0 mpi/impi/2021.3.0 netcdf4/4.8.1-parallel
+# setenv NCDFC    /usr/local/other/netcdf4/4.8.1/intel/2021.3.0/
+# setenv NCDF     /usr/local/other/netcdf4/4.8.1/intel/2021.3.0/
+# setenv EXTRANCDF `nf-config --flibs`

--- a/config/intelIF_setup-NCCS_NASA
+++ b/config/intelIF_setup-NCCS_NASA
@@ -1,0 +1,49 @@
+#
+# ---------------------------------------------------------------------
+# Common definitions for x64_64 ifort, single processor, real*4
+# removed -mcmodel=medium for compatibility with standard netCDF build
+# ---------------------------------------------------------------------
+#
+# MACROS      DESCRIPTIONS:
+#
+# FC:         Fortran 90 compiler.
+# FCFFLAGS:   Fortran 90 compilation flags.
+# CC:         C compiler.
+# CCFLAGS:    C compilation flags.
+# CPP:        cpp preprocessor (may be implied by FC).
+# CPPFLAGS:   cpp -D macro flags.
+# LD:         Loader.
+# LDFLAGS:    Loader flags.
+# EXTRALIBS:  Extra local libraries (if any).
+#
+FC            =	mpiifort
+FCFFLAGS      =	-traceback -xHost -O3 -fp-model precise -ftz -align array64byte -convert big_endian -assume byterecl -warn nogeneral -diag-disable 10212
+CC            =	mpiicc
+CCFLAGS       =	-traceback -xHost -O
+CPP           =	cpp -P
+CPPFLAGS      =	-DIA32 -DREAL4
+LD            =	$(FC)
+LDFLAGS       =	-V $(FCFFLAGS)
+EXTRALIBS     =
+
+#
+# --- generic make definitions
+#
+SHELL         = /bin/sh
+RM            = \rm -f
+
+#
+# rules.
+#
+
+.f90.o:
+	$(FC)             $(FCFFLAGS) -c $*.f90
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CCFLAGS)  -c $*.c
+
+.f.o:
+	$(FC)             $(FCFFLAGS) -c $*.f
+
+.F.o:
+	$(FC) $(CPPFLAGS) $(FCFFLAGS) -c $*.F


### PR DESCRIPTION
This PR adds module and env that allow building at [NASA's NCCS](https://www.nccs.nasa.gov/) cluster. To build:
```
cd /archive/src
mv config/intelIF_setup-NCCS_NASA config/intelIF_setup
csh Make_ncdf.csh
```
See `Make_archv2mom6res.log` for details.