### PR TITLE
Modify for "conda" GNU compiler

### DIFF
--- a/archive/src/horout_nc.f
+++ b/archive/src/horout_nc.f
@@ -6545,8 +6545,20 @@ c
       character(len=4) :: yr_tmp
       integer          :: values_tmp(8)
 c
-      mons_tmp = ['January','February','March','April','May','Jun',
-     & 'July','August','September','October','November','December']
+!      mons_tmp = ['January','February','March','April','May','Jun',
+!     & 'July','August','September','October','November','December']
+      mons_tmp = ['January  ',
+     &            'February ',
+     &            'March    ',
+     &            'April    ',
+     &            'May      ',
+     &            'June     ',
+     &            'July     ',
+     &            'August   ',
+     &            'September',
+     &            'October  ',
+     &            'November ',
+     &            'December ']
 c
       call DATE_AND_TIME(VALUES=values_tmp)
 c


### PR DESCRIPTION
Code is checked using GNU compiler downloaded by miniconda from `conda-forge` channel using these libraries:
```
  - libnetcdf
  - netcdf-fortran
  - fortran-compiler
  - cxx-compiler
```
Correction:
* `archive/src/horout_nc.f`: Modify fixed-length character vector by padding with spaces, such that all items have the same number of characters.
Needed by the GNU compiler used. Likely something to do with Fortran standards...




