### PR TITLE
To build on NOAA's WCOSS2

### DIFF
--- a/Make_all.src
+++ b/Make_all.src
@@ -8,4 +8,5 @@
 #setenv ARCH sp4XLF
 #setenv ARCH xc30IF
 #
-setenv ARCH intelIF
+#setenv ARCH intelIF
+setenv ARCH xc30IF

--- a/Make_all.src
+++ b/Make_all.src
@@ -8,5 +8,5 @@
 #setenv ARCH sp4XLF
 #setenv ARCH xc30IF
 #
-#setenv ARCH intelIF
-setenv ARCH xc30IF
+setenv ARCH intelIF
+

--- a/Make_ncdf.src
+++ b/Make_ncdf.src
@@ -27,6 +27,12 @@ setenv NCDFC	 ${NETCDFC_HOME}
 setenv NCDF	 ${NETCDFFORTRAN_HOME}
 setenv EXTRANCDF "-L${NCDFC}/lib -L${NCDF}/lib -lnetcdf -lnetcdff"
 #
+# --- NOAA WCOSS-2 systems with ifort:
+#module load envvar/1.0 intel/19.1.3.304 module load PrgEnv-intel/8.1.0 craype/2.7.10 netcdf/4.7.4
+#setenv NCDFC  /apps/prod/hpc-stack/intel-19.1.3.304/netcdf/4.7.4/
+#setenv NCDF   /apps/prod/hpc-stack/intel-19.1.3.304/netcdf/4.7.4/
+#setenv EXTRANCDF `nf-config --flibs`
+#
 # --- NASA NCCS systems with mpiifort:
 # module load comp/intel/2021.3.0 mpi/impi/2021.3.0 netcdf4/4.8.1-parallel
 # setenv NCDFC    /usr/local/other/netcdf4/4.8.1/intel/2021.3.0/


### PR DESCRIPTION
This PR adds modules so as to build on [WCOSS2.](https://www.nco.ncep.noaa.gov/idsb/implementation_standards/)

Therefore it is similar to [PR 12.](https://github.com/HYCOM/HYCOM-tools/pull/12)

To build:

```
./Make_all.csh |& tee Make.log
```

